### PR TITLE
🐛 fix(check): allow underscore in package naming

### DIFF
--- a/autograder-core/src/main/java/de/firemage/autograder/core/check/naming/PackageNamingConvention.java
+++ b/autograder-core/src/main/java/de/firemage/autograder/core/check/naming/PackageNamingConvention.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 
 @ExecutableCheck(reportedProblems = {ProblemType.PACKAGE_NAMING_CONVENTION})
 public class PackageNamingConvention extends IntegratedCheck {
-    private static final Pattern PACKAGE_NAME_PATTERN = Pattern.compile("[a-z][a-z0-9]*");
+    private static final Pattern PACKAGE_NAME_PATTERN = Pattern.compile("[a-z][a-z0-9_]*");
 
     private static <T> Set<T> intersection(Set<? extends T> left, Collection<T> right) {
         Set<T> result = new HashSet<>(left);

--- a/autograder-core/src/main/resources/strings.de.ftl
+++ b/autograder-core/src/main/resources/strings.de.ftl
@@ -207,7 +207,7 @@ type-has-descriptive-name-pre-suffix = Der Name enthält unnötige Präfixe oder
 type-has-descriptive-name-exception = Eine Klasse die von Exception erbt, sollte 'Exception' am Ende ihres Namens haben
 
 package-naming-convention = Der Name eines Pakets sollte am besten ein Wort sein und alle Buchstaben sollten nach Konvention
-                            klein sein. Zudem sollten keine Sonderzeichen auftreten wie '_'. An folgenden Stellen wird das
+                            klein sein. Außer dem Zeichen '_' sollten zudem keine Sonderzeichen auftreten. An folgenden Stellen wird das
                             nicht eingehalten: '{$positions}'
 
 variable-redundant-number-suffix = Der Bezeichner '{$name}' enthält eine redundante Zahl am Ende.

--- a/autograder-core/src/main/resources/strings.en.ftl
+++ b/autograder-core/src/main/resources/strings.en.ftl
@@ -206,7 +206,7 @@ type-has-descriptive-name-pre-suffix = The name contains redundant prefixes or s
 type-has-descriptive-name-exception = A class that inherits from Exception should have 'Exception' at the end of its name
 
 package-naming-convention = The name of a package should be a single word and all letters should be lowercase by convention.
-                            Additionally, no special characters should occur like '_'. The following positions do not
+                            Except for the character '_', no special characters should appear. The following positions do not
                             adhere to this: '{$positions}'
 
 variable-redundant-number-suffix = The identifier '{$name}' has a redundant number at the end.


### PR DESCRIPTION
https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html

Co-authored-by: Dominik Fuchß <dominik.fuchss@kit.edu>