### PR TITLE
commented-out-code: coalesce consecutive comments

### DIFF
--- a/autograder-core/src/main/java/de/firemage/autograder/core/check/comment/CommentedOutCodeCheck.java
+++ b/autograder-core/src/main/java/de/firemage/autograder/core/check/comment/CommentedOutCodeCheck.java
@@ -1,44 +1,97 @@
 package de.firemage.autograder.core.check.comment;
 
+import de.firemage.autograder.core.CodePosition;
 import de.firemage.autograder.core.LocalizedMessage;
 import de.firemage.autograder.core.ProblemType;
+import de.firemage.autograder.core.Translatable;
 import de.firemage.autograder.core.check.ExecutableCheck;
 import de.firemage.autograder.core.dynamic.DynamicAnalysis;
+import de.firemage.autograder.core.file.SourcePath;
 import de.firemage.autograder.core.integrated.IntegratedCheck;
 import de.firemage.autograder.core.integrated.StaticAnalysis;
+import org.apache.commons.lang3.StringUtils;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.code.CtComment;
+import spoon.reflect.cu.SourcePosition;
 
-import java.util.List;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 @ExecutableCheck(reportedProblems = {ProblemType.COMMENTED_OUT_CODE})
 public class CommentedOutCodeCheck extends IntegratedCheck {
-    private static final List<String> INLINE_CODE_INDICATORS = List.of(";", "{", "}");
-    private static final List<String> BLOCK_CODE_INDICATORS = List.of(";", "{", "}", "=");
+    private static final Comparator<SourcePosition> POSITION_COMPARATOR =
+        Comparator.comparingInt(SourcePosition::getSourceStart);
+    private static final Translatable MESSAGE = new LocalizedMessage("commented-out-code");
 
     @Override
     protected void check(StaticAnalysis staticAnalysis, DynamicAnalysis dynamicAnalysis) {
+        Map<Path, SortedSet<SourcePosition>> files = new HashMap<>();
+
         staticAnalysis.processWith(new AbstractProcessor<CtComment>() {
             @Override
             public void process(CtComment comment) {
-                CtComment.CommentType type = comment.getCommentType();
                 String content = comment.getContent().trim();
 
-                List<String> indicators = INLINE_CODE_INDICATORS;
-                if (type == CtComment.CommentType.BLOCK) {
-                    indicators = BLOCK_CODE_INDICATORS;
-                } else if (type != CtComment.CommentType.INLINE) {
-                    return;
-                }
-
-                if (indicators.stream().anyMatch(content::contains)) {
-                    addLocalProblem(
-                        comment,
-                        new LocalizedMessage("commented-out-code"),
-                        ProblemType.COMMENTED_OUT_CODE
-                    );
+                if (StringUtils.containsAny(content, ';', '{', '}', '=')) {
+                    var position = comment.getPosition();
+                    files
+                        .computeIfAbsent(position.getFile().toPath(), path -> new TreeSet<>(POSITION_COMPARATOR))
+                        .add(position);
                 }
             }
         });
+
+        files.forEach((path, positions) -> {
+            var sourcePath = getRoot().getCompilationUnit(path).path();
+
+            var iter = positions.iterator();
+            if (!iter.hasNext()) {
+                return;
+            }
+            var running = new RunningPosition(iter.next());
+            iter.forEachRemaining(position -> {
+                var line = position.getLine();
+                var column = position.getColumn();
+                if (line == running.endLine) {
+                    running.endColumn = position.getEndColumn();
+                } else if (line == running.endLine + 1 && column == running.startColumn) {
+                    running.endLine = position.getEndLine();
+                    running.endColumn = position.getEndColumn();
+                } else {
+                    running.addProblem(sourcePath);
+                    running.startLine = line;
+                    running.startColumn = column;
+                    running.endLine = position.getEndLine();
+                    running.endColumn = position.getEndColumn();
+                }
+            });
+            running.addProblem(sourcePath);
+        });
+    }
+
+    private final class RunningPosition {
+        int startLine;
+        int endLine;
+        int startColumn;
+        int endColumn;
+
+        RunningPosition(SourcePosition position) {
+            startLine = position.getLine();
+            endLine = position.getEndLine();
+            startColumn = position.getColumn();
+            endColumn = position.getEndColumn();
+        }
+
+        void addProblem(SourcePath path) {
+            addLocalProblem(
+                new CodePosition(getRoot(), path, startLine, endLine, startColumn, endColumn),
+                MESSAGE,
+                ProblemType.COMMENTED_OUT_CODE
+            );
+        }
     }
 }

--- a/autograder-core/src/test/java/de/firemage/autograder/core/check/comment/TestCommentedOutCodeCheck.java
+++ b/autograder-core/src/test/java/de/firemage/autograder/core/check/comment/TestCommentedOutCodeCheck.java
@@ -17,11 +17,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class TestCommentedOutCodeCheck extends AbstractCheckTest {
     private static final List<ProblemType> PROBLEM_TYPES = List.of(ProblemType.COMMENTED_OUT_CODE);
 
-    void assertEqualsCode(Problem problem) {
+    void assertEqualsCode(Problem problem, int startLine, int endLine) {
         assertEquals(
             this.linter.translateMessage(new LocalizedMessage("commented-out-code")),
             this.linter.translateMessage(problem.getExplanation())
         );
+        var position = problem.getPosition();
+        assertEquals(startLine, position.startLine());
+        assertEquals(endLine, position.endLine());
     }
 
     @Test
@@ -43,9 +46,9 @@ class TestCommentedOutCodeCheck extends AbstractCheckTest {
             PROBLEM_TYPES
         );
 
-        assertEqualsCode(problems.next());
-        assertEqualsCode(problems.next());
-        assertEqualsCode(problems.next());
+        assertEqualsCode(problems.next(), 2, 2);
+        assertEqualsCode(problems.next(), 4, 4);
+        assertEqualsCode(problems.next(), 6, 6);
 
         problems.assertExhausted();
     }
@@ -71,7 +74,41 @@ class TestCommentedOutCodeCheck extends AbstractCheckTest {
             PROBLEM_TYPES
         );
 
-        assertEqualsCode(problems.next());
+        assertEqualsCode(problems.next(), 2, 8);
+
+        problems.assertExhausted();
+    }
+
+    @Test
+    void testCoalescing() throws IOException, LinterException {
+        ProblemIterator problems = this.checkIterator(
+            StringSourceInfo.fromSourceString(
+                JavaVersion.JAVA_17,
+                "Test",
+                """
+                    public class Test {
+                        // int a = b;
+
+                        // if (a) {
+                        //    print(a);
+                        // }
+                         // differentIndent();
+
+                        // while (true) {
+                        /*     a += 7;
+
+                             */ // another = one;
+                        // }
+                    }
+                    """
+            ),
+            PROBLEM_TYPES
+        );
+
+        assertEqualsCode(problems.next(), 2, 2);
+        assertEqualsCode(problems.next(), 4, 6);
+        assertEqualsCode(problems.next(), 7, 7);
+        assertEqualsCode(problems.next(), 9, 13);
 
         problems.assertExhausted();
     }


### PR DESCRIPTION
This does not use different character lists for block and inline comments anymore.
In the future we could investigate using more sophisticated detection, for example with regular expressions.