### PR TITLE
improve commented out code check with JavaParser

### DIFF
--- a/autograder-core/pom.xml
+++ b/autograder-core/pom.xml
@@ -76,6 +76,13 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
         </dependency>
+
+        <!-- JavaParser -->
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>${javaparser.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/autograder-core/src/main/java/de/firemage/autograder/core/check/comment/CommentedOutCodeCheck.java
+++ b/autograder-core/src/main/java/de/firemage/autograder/core/check/comment/CommentedOutCodeCheck.java
@@ -1,11 +1,12 @@
 package de.firemage.autograder.core.check.comment;
 
+import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.StaticJavaParser;
+import de.firemage.autograder.api.Translatable;
 import de.firemage.autograder.core.CodePosition;
 import de.firemage.autograder.core.LocalizedMessage;
 import de.firemage.autograder.core.ProblemType;
-import de.firemage.autograder.api.Translatable;
 import de.firemage.autograder.core.check.ExecutableCheck;
-
 import de.firemage.autograder.core.file.SourcePath;
 import de.firemage.autograder.core.integrated.IntegratedCheck;
 import de.firemage.autograder.core.integrated.StaticAnalysis;
@@ -15,8 +16,11 @@ import spoon.reflect.code.CtComment;
 import spoon.reflect.cu.SourcePosition;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -44,7 +48,7 @@ public class CommentedOutCodeCheck extends IntegratedCheck {
                 }
                 String content = comment.getContent().trim();
 
-                if (StringUtils.containsAny(content, ';', '{', '}', '=')) {
+                if (isValidCode(content)) {
                     var position = comment.getPosition();
                     files
                         .computeIfAbsent(position.getFile().toPath(), path -> new TreeSet<>(POSITION_COMPARATOR))
@@ -79,6 +83,59 @@ public class CommentedOutCodeCheck extends IntegratedCheck {
             });
             running.addProblem(sourcePath);
         });
+    }
+
+    private static boolean isValidCode(String content) {
+        return !content.isEmpty() && containsSpecialCharacters(content) && isValidCodeInternal(content);
+    }
+    
+    private static boolean containsSpecialCharacters(String content) {
+        return StringUtils.containsAny(content, ';', '{', '}', '=', '(', ')', '-', '<', '>', '?', ':', '+', '.', ',');
+    }
+
+    private static boolean isValidCodeInternal(String content) {
+        return prepareCode(content).stream().anyMatch(formatted -> {
+                    try {
+                        StaticJavaParser.parseBlock(formatted);
+                        return true;
+                    } catch (ParseProblemException e) {
+                        return false;
+                    }
+                });
+    }
+
+    private static List<String> prepareCode(String content) {
+        String stripped = content.strip();
+        return wrapAsBlock(getDifferentVersions(stripped));
+    }
+
+    private static Collection<String> getDifferentVersions(String original) {
+        Set<String> options = new HashSet<>();
+        options.add(original.endsWith(";") ? original : original + ";");
+        options.add(formatClosedBlock(original));
+        return options;
+    }
+
+    private static String formatClosedBlock(String original) {
+        int differenceClosing = StringUtils.countMatches(original, '}') - StringUtils.countMatches(original, '{');
+        if (differenceClosing == 0) {
+            return original;
+        }
+        
+        return differenceClosing > 0 
+                ? "{".repeat(differenceClosing) + original 
+                : original + "}".repeat(-differenceClosing);
+    }
+
+    private static List<String> wrapAsBlock(Collection<String> differentVersions) {
+        return differentVersions.stream()
+                .map(content -> {
+                    if (!content.startsWith("{") || !content.endsWith("}")) {
+                        return "{" + content + "}";
+                    }
+                    return content;
+                })
+                .toList();
     }
 
     private final class RunningPosition {

--- a/autograder-core/src/main/java/de/firemage/autograder/core/check/comment/CommentedOutCodeCheck.java
+++ b/autograder-core/src/main/java/de/firemage/autograder/core/check/comment/CommentedOutCodeCheck.java
@@ -112,19 +112,19 @@ public class CommentedOutCodeCheck extends IntegratedCheck {
     private static Collection<String> getDifferentVersions(String original) {
         Set<String> options = new HashSet<>();
         options.add(original.endsWith(";") ? original : original + ";");
-        options.add(formatClosedBlock(original));
+        options.add(formatBrackets(formatBrackets(formatBrackets(original, '{', '}'), '(', ')'), '[', ']'));
         return options;
     }
 
-    private static String formatClosedBlock(String original) {
-        int differenceClosing = StringUtils.countMatches(original, '}') - StringUtils.countMatches(original, '{');
-        if (differenceClosing == 0) {
+    private static String formatBrackets(String original, char opening, char closing) {
+        int difference = StringUtils.countMatches(original, closing) - StringUtils.countMatches(original, opening);
+        if (difference == 0) {
             return original;
         }
         
-        return differenceClosing > 0 
-                ? "{".repeat(differenceClosing) + original 
-                : original + "}".repeat(-differenceClosing);
+        return difference > 0 
+                ? String.valueOf(opening).repeat(difference) + original 
+                : original + String.valueOf(closing).repeat(-difference);
     }
 
     private static List<String> wrapAsBlock(Collection<String> differentVersions) {

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <spoon.version>11.1.1-beta-21</spoon.version>
         <fluent.version>0.70</fluent.version>
         <reflections.version>0.10.2</reflections.version>
+        <javaparser.version>3.26.1</javaparser.version>
 
         <revision>0.5.13</revision>
     </properties>


### PR DESCRIPTION
The current implementation of checking whether a comment is a code fragment is naive and creates many false positives. This PR introduces the JavaParser tool which is used to surely detect valid code fragments. Since the code must be compilable to be detected, some preformatting is used. Any content that doesn't contain special characters is ignored.