### PR TITLE
fix code comment block not being detected

### DIFF
--- a/autograder-core/src/main/java/de/firemage/autograder/core/check/comment/CommentedOutCodeCheck.java
+++ b/autograder-core/src/main/java/de/firemage/autograder/core/check/comment/CommentedOutCodeCheck.java
@@ -16,6 +16,7 @@ import spoon.reflect.code.CtComment;
 import spoon.reflect.cu.SourcePosition;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -48,7 +49,9 @@ public class CommentedOutCodeCheck extends IntegratedCheck {
                 }
                 String content = comment.getContent().trim();
 
-                if (isValidCode(content)) {
+                if (isValidCode(content) || 
+                        comment.getCommentType().equals(CtComment.CommentType.BLOCK) 
+                                && Arrays.stream(content.split("\n")).anyMatch(CommentedOutCodeCheck::isValidCode)) {
                     var position = comment.getPosition();
                     files
                         .computeIfAbsent(position.getFile().toPath(), path -> new TreeSet<>(POSITION_COMPARATOR))

--- a/autograder-core/src/test/java/de/firemage/autograder/core/check/comment/TestCommentedOutCodeCheck.java
+++ b/autograder-core/src/test/java/de/firemage/autograder/core/check/comment/TestCommentedOutCodeCheck.java
@@ -114,7 +114,7 @@ class TestCommentedOutCodeCheck extends AbstractCheckTest {
     }
 
     @Test
-    void testJavadoc() throws IOException, LinterException {
+    void testNoCodeComments() throws IOException, LinterException {
         ProblemIterator problems = this.checkIterator(
             StringSourceInfo.fromSourceString(
                 JavaVersion.JAVA_17,
@@ -127,11 +127,46 @@ class TestCommentedOutCodeCheck extends AbstractCheckTest {
                      */
                     public class RunCommand {
                         // some comment
+                        
+                        /*
+                        A multi line comment with special character;
+                        two words
+                        */
                     }
                     """
             ),
             PROBLEM_TYPES
         );
+
+        problems.assertExhausted();
+    }
+
+    @Test
+    void testMultilineCodeReal() throws IOException, LinterException {
+        ProblemIterator problems = this.checkIterator(
+                StringSourceInfo.fromSourceString(
+                        JavaVersion.JAVA_17,
+                        "Test",
+                        """
+                                public class Test {
+                                
+                                    /*
+                                    public int add() {
+                                        return 1 + 1;
+                                    }
+                                
+                                    private int subtract() {
+                                        return 1 - 1;
+                                    }
+                                     */
+                                }
+                                
+                            """
+                ),
+                PROBLEM_TYPES
+        );
+
+        assertEqualsCode(problems.next(), 3, 11);
 
         problems.assertExhausted();
     }


### PR DESCRIPTION
This PR fixes commented-out code blocks sometimes not being detected by the corresponding check. Such a case occurs when the code, directly wrapped by a block structure, is not parseable by JavaParser.

It is assumed that a commented-out code block contains at least one line of code that is parseable. A block comment is therefore split into its lines and applies the check for inline comments.